### PR TITLE
Fix: Remove Hardcoded API Key

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,2 +1,2 @@
 # Rename this file to .env.local and set your api key
-VUE_APP_FM_KEY="6ae5a929-4cf5-4233-71f9-16307e6f2414"
+VUE_APP_FM_KEY=""


### PR DESCRIPTION
This pull request addresses a high-severity security vulnerability by removing the hardcoded API key from the `.env.local` file.

### Vulnerability Details
- **File**: /.env.local, Line 2
- **Severity**: High
- **Detected by**: Gitleaks Scanner
- **Tracking ID**: 2e692e99c2c1511e7cb7aad13fad03c6a1b51483a31153a709a868cd10b49c4b

Please review and merge this fix to enhance the security of the application.