### PR TITLE
Fix: Remove Hardcoded API Key from Testing File

### DIFF
--- a/.env.testing
+++ b/.env.testing
@@ -1,2 +1,2 @@
 # Rename this file to .env.test and set your api key
-VUE_APP_FM_KEY="6ae5a929-4cf5-4233-71f9-16307e6f2428"
+VUE_APP_FM_KEY=""


### PR DESCRIPTION
This pull request removes the hardcoded API key from the `.env.testing` file to address a high-severity security vulnerability.

### Vulnerability Details
- **File**: /.env.testing, Line 2
- **Severity**: High
- **Detected by**: Gitleaks Scanner
- **Tracking ID**: a0fe33314744c08c8d33cc9b4b437d47d8aa219ed8b3ef6307855343256e0d72

Please review and merge this fix to secure the application.